### PR TITLE
Correctly pass task object into thread, fixing race condition

### DIFF
--- a/lib/cloudtasker/local_server.rb
+++ b/lib/cloudtasker/local_server.rb
@@ -69,7 +69,7 @@ module Cloudtasker
 
       # Process tasks
       while @threads[queue].count < max_threads && (task = Cloudtasker::Backend::RedisTask.pop(queue))
-        @threads[queue] << Thread.new { process_task(task) }
+        @threads[queue] << Thread.new(task) {|task| process_task(task) }
       end
     end
 

--- a/lib/cloudtasker/local_server.rb
+++ b/lib/cloudtasker/local_server.rb
@@ -69,7 +69,7 @@ module Cloudtasker
 
       # Process tasks
       while @threads[queue].count < max_threads && (task = Cloudtasker::Backend::RedisTask.pop(queue))
-        @threads[queue] << Thread.new(task) {|task| process_task(task) }
+        @threads[queue] << Thread.new(task) { |task| process_task(task) }
       end
     end
 

--- a/lib/cloudtasker/local_server.rb
+++ b/lib/cloudtasker/local_server.rb
@@ -69,7 +69,7 @@ module Cloudtasker
 
       # Process tasks
       while @threads[queue].count < max_threads && (task = Cloudtasker::Backend::RedisTask.pop(queue))
-        @threads[queue] << Thread.new(task) { |task| process_task(task) }
+        @threads[queue] << Thread.new(task) { |t| process_task(t) }
       end
     end
 


### PR DESCRIPTION
The RedisTask object is not properly passed into the processing queue thread in the local_server. In our environment this creates a race condition which causes the local_server to randomly fail.