### PR TITLE
OIDC auth token for Cloud Run services requiring authentication

### DIFF
--- a/cloudtasker.gemspec
+++ b/cloudtasker.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jwt'
   spec.add_dependency 'redis'
   spec.add_dependency 'retriable'
+  spec.add_dependency 'faraday'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/lib/cloudtasker/config.rb
+++ b/lib/cloudtasker/config.rb
@@ -8,7 +8,7 @@ module Cloudtasker
     attr_accessor :redis, :store_payloads_in_redis
     attr_writer :secret, :gcp_location_id, :gcp_project_id,
                 :gcp_queue_prefix, :processor_path, :logger, :mode, :max_retries,
-                :dispatch_deadline, :on_error, :on_dead
+                :dispatch_deadline, :on_error, :on_dead, :oidc_enabled
 
     # Max Cloud Task size in bytes
     MAX_TASK_SIZE = 100 * 1024 # 100 KB
@@ -279,5 +279,15 @@ module Cloudtasker
       yield @server_middleware if block_given?
       @server_middleware
     end
+  end
+  
+  #
+  # Return if oidc is enabled. This can be enable to allow cloud tasker to work with google cloud run services that
+  # require authentication. Defaults to false.
+  #
+  # @return [Boolean] Flag to enable oidc.
+  #
+  def oidc_enabled
+    @oidc_enabled || false
   end
 end


### PR DESCRIPTION
As mention in issue #28, currently google cloud run services that require authentication cannot currently use cloudtasker.
These 3 commits included in the pull request aim to add the oidc auth token feature to cloudtasker.
In these commits the following changes are added

-  Add the faraday http client to the cloudtakser.gemspec
- Add a oidc_enable flag to the config
- Add logic to fetch the oidc auth token from the google metadata server using the faraday http client in the authenticator if oidc_enabled is set to true