### PR TITLE
Fix issue when :until_executed lock prevents cron job from scheduling next job

### DIFF
--- a/lib/cloudtasker/cron/job.rb
+++ b/lib/cloudtasker/cron/job.rb
@@ -188,9 +188,6 @@ module Cloudtasker
         # Abort and reject job if this cron instance is not expected.
         return true unless expected_instance?
 
-        # Schedule the next instance of the job
-        schedule! unless retry_instance?
-
         # Flag the cron instance as processing.
         flag(:processing)
 
@@ -199,6 +196,9 @@ module Cloudtasker
 
         # Flag the cron instance as done
         flag(:done)
+
+        # Schedule the next instance of the job
+        schedule! unless retry_instance?
       end
     end
   end

--- a/lib/cloudtasker/cron/middleware.rb
+++ b/lib/cloudtasker/cron/middleware.rb
@@ -12,7 +12,15 @@ module Cloudtasker
     module Middleware
       def self.configure
         Cloudtasker.configure do |config|
-          config.server_middleware { |c| c.add(Middleware::Server) }
+          config.server_middleware do |c|
+            # Make sure cron server middleware always run before unique job middleware
+            # to prevent some rare cases where the next cron job cannot be scheduled because of lock.
+            if defined?(::Cloudtasker::UniqueJob::Middleware::Server)
+              c.insert_before(Cloudtasker::UniqueJob::Middleware::Server, Middleware::Server)
+            else
+              c.add(Middleware::Server)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Hi [alachaum](https://github.com/keypup-io/cloudtasker/commits?author=alachaum), thank you for the great work again.

We just found a rare case when using both cron job and unique job (:until_executed in specific).

Basically, we have a job with `cloudtasker_options lock: :until_executed` and the job is scheduled by cron job feature. The issue could happen like below:

1. When it first runs, because of no lock (I don't know this should be the case? Perhaps a separate thing need to look into?), it schedules next job successfully, now the lock is created.
2. Now the job will be processed within Unique server middleware, because of the lock just has been created in step 1, the actual job will be rejected/bypassed (we are using default reject conflict strategy, but the result is still `Job done`. The lock isn't cleared <- This is an issue.
3. Next time it runs, when it tries to schedule next run, an error will be raised here because of the lock in the step 2. -> Job fails.

So the solution we come up with is that:
1. Cron job server middleware always need to run before Unique job -> this to make sure no lock left when we try to schedule next run.
2. Only schedule next run in cron job if the job has been processed successfully and lock has been cleared.

Any thoughts?