### PR TITLE
Support HTTPS for Redis task backend

### DIFF
--- a/lib/cloudtasker/backend/redis_task.rb
+++ b/lib/cloudtasker/backend/redis_task.rb
@@ -257,7 +257,9 @@ module Cloudtasker
         @http_client ||=
           begin
             uri = URI(http_request[:url])
-            Net::HTTP.new(uri.host, uri.port).tap { |e| e.read_timeout = dispatch_deadline }
+            http = Net::HTTP.new(uri.host, uri.port).tap { |e| e.read_timeout = dispatch_deadline }
+            http.use_ssl = true if uri.instance_of?(URI::HTTPS)
+            http
           end
       end
 


### PR DESCRIPTION
### The problem this PR fixes:
Setting `config.processor_host` to an HTTPS URL and `config.mode` to `:development` leads to processing errors as the Redis task backend doesn't configure the `Net::HTTP` client to use SSL.