### PR TITLE
chore: make ssl verify mode configurable [#100]

### DIFF
--- a/lib/cloudtasker/backend/redis_task.rb
+++ b/lib/cloudtasker/backend/redis_task.rb
@@ -52,7 +52,7 @@ module Cloudtasker
       end
 
       #
-      # Reeturn all tasks ready to process.
+      # Return all tasks ready to process.
       #
       # @param [String] queue The queue to retrieve items from.
       #

--- a/lib/cloudtasker/backend/redis_task.rb
+++ b/lib/cloudtasker/backend/redis_task.rb
@@ -259,6 +259,7 @@ module Cloudtasker
             uri = URI(http_request[:url])
             http = Net::HTTP.new(uri.host, uri.port).tap { |e| e.read_timeout = dispatch_deadline }
             http.use_ssl = true if uri.instance_of?(URI::HTTPS)
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE unless Cloudtasker.config.ssl_verify_mode
             http
           end
       end

--- a/lib/cloudtasker/config.rb
+++ b/lib/cloudtasker/config.rb
@@ -8,7 +8,7 @@ module Cloudtasker
     attr_accessor :redis, :store_payloads_in_redis, :gcp_queue_prefix
     attr_writer :secret, :gcp_location_id, :gcp_project_id,
                 :processor_path, :logger, :mode, :max_retries,
-                :dispatch_deadline, :on_error, :on_dead, :oidc
+                :dispatch_deadline, :on_error, :on_dead, :oidc, :ssl_verify_mode
 
     # Max Cloud Task size in bytes
     MAX_TASK_SIZE = 100 * 1024 # 100 KB
@@ -45,6 +45,7 @@ module Cloudtasker
     # Default values
     DEFAULT_LOCATION_ID = 'us-east1'
     DEFAULT_PROCESSOR_PATH = '/cloudtasker/run'
+    DEFAULT_SSL_VERIFY_MODE = true
 
     # Default queue values
     DEFAULT_JOB_QUEUE = 'default'
@@ -163,9 +164,9 @@ module Cloudtasker
 
       # Check if Rails supports host filtering
       return unless val &&
-                    defined?(Rails) &&
-                    Rails.application.config.respond_to?(:hosts) &&
-                    Rails.application.config.hosts&.any?
+        defined?(Rails) &&
+        Rails.application.config.respond_to?(:hosts) &&
+        Rails.application.config.hosts&.any?
 
       # Add processor host to the list of authorized hosts
       Rails.application.config.hosts << val.gsub(%r{https?://}, '')
@@ -287,6 +288,15 @@ module Cloudtasker
       @server_middleware ||= Middleware::Chain.new
       yield @server_middleware if block_given?
       @server_middleware
+    end
+
+    #
+    # Return the ssl verify mode for the Cloudtasker local server.
+    #
+    # @return [Boolean] The ssl verify mode for the Cloudtasker local server.
+    #
+    def ssl_verify_mode
+      @ssl_verify_mode.nil? ? DEFAULT_SSL_VERIFY_MODE : @ssl_verify_mode
     end
   end
 end

--- a/lib/cloudtasker/config.rb
+++ b/lib/cloudtasker/config.rb
@@ -164,9 +164,9 @@ module Cloudtasker
 
       # Check if Rails supports host filtering
       return unless val &&
-        defined?(Rails) &&
-        Rails.application.config.respond_to?(:hosts) &&
-        Rails.application.config.hosts&.any?
+                    defined?(Rails) &&
+                    Rails.application.config.respond_to?(:hosts) &&
+                    Rails.application.config.hosts&.any?
 
       # Add processor host to the list of authorized hosts
       Rails.application.config.hosts << val.gsub(%r{https?://}, '')

--- a/spec/cloudtasker/config_spec.rb
+++ b/spec/cloudtasker/config_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Cloudtasker::Config do
   let(:on_error) { ->(e, w) {} }
   let(:on_dead) { ->(e, w) {} }
   let(:oidc) { nil }
+  let(:ssl_verify_mode) { false }
 
   let(:rails_hosts) { [] }
   let(:rails_secret) { 'rails_secret' }
@@ -46,6 +47,7 @@ RSpec.describe Cloudtasker::Config do
       c.on_error = on_error
       c.on_dead = on_dead
       c.oidc = oidc
+      c.ssl_verify_mode = ssl_verify_mode
     end
 
     Cloudtasker.config
@@ -318,6 +320,20 @@ RSpec.describe Cloudtasker::Config do
       let(:oidc) { { audience: 'https://foo.bar' } }
 
       it { expect { oidc_config }.to raise_error(StandardError, described_class::OIDC_EMAIL_MISSING_ERROR) }
+    end
+  end
+
+  describe '#ssl_verify_mode' do
+    subject { config.ssl_verify_mode }
+
+    context 'with value specified via config' do
+      it { is_expected.to eq(ssl_verify_mode) }
+    end
+
+    context 'with no value' do
+      let(:ssl_verify_mode) { nil }
+
+      it { is_expected.to eq(described_class::DEFAULT_SSL_VERIFY_MODE) }
     end
   end
 


### PR DESCRIPTION
This is a proposal on how to fix the issue here:
https://github.com/keypup-io/cloudtasker/issues/100

It is missing a unit test for `redis_rask.rb`.

I wanted to discuss the interface with you first. I decided for a boolean in the config to not have a dependency to `'net/http'` in there, but passing the constant `OpenSSL::SSL::VERIFY_NONE` directly from the config could also be an option.

What do you think?