### PR TITLE
Add option to allow `ActiveJob` to manage retries on app-level first

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,22 @@ Cloudtasker.configure do |config|
   #
   # config.max_retries = 10
 
+  # 
+  # Specify whether ActiveJob's or CloudTask's retry mechanism should be used.
+  # - :provider => Use CloudTask's retry management.
+  # - :active_job => Rely on ActiveJob to manage retries, e.g. using `retry_on`.
+  # 
+  # ActiveJob has its own mechanism for retries and will reschedule the job and prevent it 
+  # from failing hard until a configured threshold is met. Then, the error is allowed to bubble up 
+  # to the underlying queuing system (in this case CloudTask). To prevent CloudTask from retrying
+  # on top of ActiveJob, pass a (potentially empty) block to `retry_on`.
+  # 
+  # When `:active_job` is chosen, `max_retries` will have no effect!
+  #
+  # Default: `:provider` (CloudTask)
+  #
+  # config.retry_mechanism = :active_job
+
   #
   # Specify the redis connection hash.
   #

--- a/lib/cloudtasker/config.rb
+++ b/lib/cloudtasker/config.rb
@@ -7,7 +7,7 @@ module Cloudtasker
   class Config
     attr_accessor :redis, :store_payloads_in_redis, :gcp_queue_prefix
     attr_writer :secret, :gcp_location_id, :gcp_project_id,
-                :processor_path, :logger, :mode, :max_retries,
+                :processor_path, :logger, :mode, :max_retries, :retry_mechanism,
                 :dispatch_deadline, :on_error, :on_dead, :oidc
 
     # Max Cloud Task size in bytes
@@ -111,6 +111,19 @@ module Cloudtasker
     #
     def max_retries
       @max_retries ||= DEFAULT_MAX_RETRY_ATTEMPTS
+    end
+
+    #
+    # Configures who is responsible for tracking and managing retries.
+    # Defaults to `:provider`.
+    #   - :provider => Use CloudTask's retry management.
+    #   - :active_job => Rely on ActiveJob first to manage retries, e.g. using `retry_on`.
+    #       Ignores the CloudTask `RetryCount` header.
+    #
+    # @return [<Type>] <description>
+    #
+    def retry_mechanism
+      @retry_mechanism ||= :provider
     end
 
     #

--- a/spec/active_job/queue_adapters/cloudtasker_adapter/job_wrapper_spec.rb
+++ b/spec/active_job/queue_adapters/cloudtasker_adapter/job_wrapper_spec.rb
@@ -8,24 +8,63 @@ if defined?(Rails)
 
     subject(:worker) { described_class.new(**example_job_wrapper_args.merge(task_id: '00000001')) }
 
-    let(:example_unreconstructed_job_serialization) do
-      example_job_serialization.except('job_id', 'queue_name', 'provider_job_id', 'executions', 'priority')
+    let(:example_job_serialization) do
+      example_job.serialize.except('job_id', 'priority', 'queue_name', 'provider_job_id')
     end
 
-    let(:example_reconstructed_job_serialization) do
-      example_job_serialization.merge(
-        'job_id' => worker.job_id,
-        'queue_name' => worker.job_queue,
-        'provider_job_id' => worker.task_id,
-        'executions' => 0,
-        'priority' => nil
-      )
+    context 'when the CloudTask retry mechanism is used' do
+      let(:example_unreconstructed_job_serialization) do
+        example_job_serialization.except('job_id', 'queue_name', 'provider_job_id', 'executions', 'priority')
+      end
+
+      let(:example_reconstructed_job_serialization) do
+        example_job_serialization.merge(
+          'job_id' => worker.job_id,
+          'queue_name' => worker.job_queue,
+          'provider_job_id' => worker.task_id,
+          'executions' => 0,
+          'priority' => nil
+        )
+      end
+
+      describe '#perform' do
+        it "calls 'ActiveJob::Base.execute' with the job serialization" do
+          expect(ActiveJob::Base).to receive(:execute).with(example_reconstructed_job_serialization)
+          worker.perform(example_unreconstructed_job_serialization)
+        end
+      end
     end
 
-    describe '#perform' do
-      it "calls 'ActiveJob::Base.execute' with the job serialization" do
-        expect(ActiveJob::Base).to receive(:execute).with(example_reconstructed_job_serialization)
-        worker.perform(example_unreconstructed_job_serialization)
+    context 'when the ActiveJob retry mechanism is used' do
+      around do |example|
+        Cloudtasker.config.retry_mechanism = :active_job
+        example.call
+        Cloudtasker.config.retry_mechanism = :provider
+      end
+
+      before do
+        example_job.executions = 1
+      end
+
+      let(:example_unreconstructed_job_serialization) do
+        example_job_serialization.except('job_id', 'queue_name', 'provider_job_id', 'priority')
+      end
+
+      let(:example_reconstructed_job_serialization) do
+        example_job_serialization.merge(
+          'job_id' => worker.job_id,
+          'executions' => 1,
+          'queue_name' => worker.job_queue,
+          'provider_job_id' => worker.task_id,
+          'priority' => nil
+        )
+      end
+
+      describe '#perform' do
+        it "calls 'ActiveJob::Base.execute' with the job serialization" do
+          expect(ActiveJob::Base).to receive(:execute).with(example_reconstructed_job_serialization)
+          worker.perform(example_unreconstructed_job_serialization)
+        end
       end
     end
   end

--- a/spec/cloudtasker/config_spec.rb
+++ b/spec/cloudtasker/config_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Cloudtasker::Config do
   let(:logger) { Logger.new(nil) }
   let(:mode) { :production }
   let(:max_retries) { 10 }
+  let(:retry_mechanism) { :provider }
   let(:store_payloads_in_redis) { 10 }
   let(:dispatch_deadline) { 15 * 60 }
   let(:on_error) { ->(e, w) {} }
@@ -41,6 +42,7 @@ RSpec.describe Cloudtasker::Config do
       c.processor_host = processor_host
       c.processor_path = processor_path
       c.max_retries = max_retries
+      c.retry_mechanism = retry_mechanism
       c.store_payloads_in_redis = store_payloads_in_redis
       c.dispatch_deadline = dispatch_deadline
       c.on_error = on_error
@@ -94,6 +96,20 @@ RSpec.describe Cloudtasker::Config do
       let(:max_retries) { nil }
 
       it { is_expected.to eq(described_class::DEFAULT_MAX_RETRY_ATTEMPTS) }
+    end
+  end
+
+  describe '#retry_mechanism' do
+    subject { config.retry_mechanism }
+
+    context 'with value specified via config' do
+      it { is_expected.to eq(retry_mechanism) }
+    end
+
+    context 'with no value' do
+      let(:retry_mechanism) { nil }
+
+      it { is_expected.to eq(:provider) }
     end
   end
 


### PR DESCRIPTION
First off: a big thank you to all contributors that made this Gem possible! 🚀 

### Motivation 

Our company ran into some unfortunate circumstances regarding retries and failing jobs with an app that relies on Rails' `ActiveJob` and (depending on the tenant) `Sidekiq`/`Redis` or `Cloudtasker`/`CloudTask` as the backend:  
due to the behavior already described in 
- https://github.com/keypup-io/cloudtasker/issues/41 ,

some jobs were retried endlessly in the CloudTask-based stacks.

### Proposed solution 
My suggestion would be to let a config option `retry_mechanism` control whether `ActiveJob`s `executions` counter is overridden with the value of CloudTask's `RetryCounter` header. 
As implemented, `ActiveJob` should be able to handle retries using `retry_on` and only after those are used up let the backend handle further retries.

### Drawbacks of the proposed solution

- `config.max_retries` will be without effect in the implementation at hand if `ActiveJob` is chosen, as `executions` is not "handed back" to Cloudtasker to update once `ActiveJob` is done retrying and bubbles errors up for the backend to handle.
If it is acceptable to introduce a retry counter variable that does not clash with AJ's `executions`, e.g. like Sidekiq's `retry_count`, this could be a possible way out.

- The behavior of first handling retries on application level and then on backend/adapter level is probably quite unintuitive and must be documented to prevent people from accidentally shooting themselves in the foot.

- a Rails-specific config variable is introduced that has no relevance for projects that do not even use the `CloudtaskerAdapter`

### Alternative
A more elaborate mechanism could provide the means to configure both app-level and backend-level retries at the same time. This would include either a "hand-off" of the execution/retry counters when the responsibility changes or separate means of tracking and applying executions/retries.

---

It would be great if you could consider including this change and/or sharing your thoughts on how this contribution can be improved.