### PR TITLE
Add enqueue_after_transaction_commit? for rails 7.2.1

### DIFF
--- a/lib/active_job/queue_adapters/cloudtasker_adapter.rb
+++ b/lib/active_job/queue_adapters/cloudtasker_adapter.rb
@@ -38,6 +38,13 @@ module ActiveJob
         build_worker(job).schedule(time_at: Time.at(precise_timestamp))
       end
 
+      # Determines if enqueuing will check and wait for an associated transaction completes before enqueuing
+      #
+      # @return [Boolean] True always as this is the default from QueueAdapters::AbstractAdapter
+      def enqueue_after_transaction_commit?
+        true
+      end
+
       private
 
       def build_worker(job)

--- a/spec/active_job/queue_adapters/cloudtasker_adapter_spec.rb
+++ b/spec/active_job/queue_adapters/cloudtasker_adapter_spec.rb
@@ -52,5 +52,11 @@ if defined?(Rails)
         adapter.enqueue_at(example_job, example_execution_timestamp)
       end
     end
+
+    describe '#enqueue_after_transaction_commit?' do
+      it 'returns true' do
+        expect(adapter.enqueue_after_transaction_commit?).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/keypup-io/cloudtasker/issues/125 by adding the new required method. This strategy avoids a dependency on Rails `>= 7.2.1` so I think it is preferred for now.