### PR TITLE
Add the option to set max_retries to 0 or false to disable retries

### DIFF
--- a/lib/cloudtasker/worker.rb
+++ b/lib/cloudtasker/worker.rb
@@ -150,7 +150,7 @@ module Cloudtasker
       # @return [Integer] The number of retries.
       #
       def max_retries
-        cloudtasker_options_hash[:max_retries] || Cloudtasker.config.max_retries
+        cloudtasker_options_hash[:max_retries].nil? ? Cloudtasker.config.max_retries : cloudtasker_options_hash[:max_retries] || 0
       end
     end
 


### PR DESCRIPTION
### Description

Update the max_retries configuration to allow setting it to 0 or false to disable worker retries.

Previously, the issue was that 0 was evaluated as false in the || condition, causing the default configuration to be used instead of applying a value of 0.