### PR TITLE
Add UntilCompleted Unique Job Lock Strategy

### DIFF
--- a/docs/UNIQUE_JOBS.md
+++ b/docs/UNIQUE_JOBS.md
@@ -70,6 +70,7 @@ For each lock strategy the table specifies the lock period (start/end) and which
 | `until_executing` | The job is scheduled | The job starts processing | `reject` (default) or `raise` |
 | `while_executing` | The job starts processing | The job ends processing | `reject` (default), `reschedule` or `raise` |
 | `until_executed` | The job is scheduled | The job ends processing | `reject` (default) or `raise` |
+| `until_completed` | The job is scheduled | The job completes successfully or a DeadWorkerError is raised | `reject` (default) or `raise` |
 
 ## Available conflict strategies
 

--- a/lib/cloudtasker/unique_job/lock/until_completed.rb
+++ b/lib/cloudtasker/unique_job/lock/until_completed.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Cloudtasker
+  module UniqueJob
+    module Lock
+      # Conflict if any other job with the same args is scheduled or moved to execution
+      # while the first job is pending or executing. Unlocks only on successful completion
+      # or when a DeadWorkerError is raised.
+      class UntilCompleted < BaseLock
+        #
+        # Acquire a lock for the job and trigger a conflict
+        # if the lock could not be acquired.
+        #
+        def schedule(&block)
+          job.lock!
+          yield
+        rescue LockError
+          conflict_instance.on_schedule(&block)
+        end
+
+        #
+        # Acquire a lock for the job and trigger a conflict
+        # if the lock could not be acquired.
+        #
+        def execute(&block)
+          job.lock!
+          yield
+          # Unlock on successful completion
+          job.unlock!
+        rescue LockError
+          conflict_instance.on_execute(&block)
+        rescue Cloudtasker::DeadWorkerError
+          # Unlock when DeadWorkerError is raised
+          job.unlock!
+          raise
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudtasker/unique_job/middleware.rb
+++ b/lib/cloudtasker/unique_job/middleware.rb
@@ -14,6 +14,7 @@ require_relative 'lock/no_op'
 require_relative 'lock/until_executed'
 require_relative 'lock/until_executing'
 require_relative 'lock/while_executing'
+require_relative 'lock/until_completed'
 
 require_relative 'job'
 

--- a/spec/cloudtasker/unique_job/lock/until_completed_spec.rb
+++ b/spec/cloudtasker/unique_job/lock/until_completed_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'cloudtasker/unique_job/middleware'
+
+RSpec.describe Cloudtasker::UniqueJob::Lock::UntilCompleted do
+  let(:worker) { TestWorker.new(job_args: [1, 2]) }
+  let(:job) { Cloudtasker::UniqueJob::Job.new(worker) }
+  let(:lock) { described_class.new(job) }
+
+  it_behaves_like Cloudtasker::UniqueJob::Lock::BaseLock
+
+  describe '#schedule' do
+    context 'with lock available' do
+      before { allow(job).to receive(:lock!) }
+      it { expect { |b| lock.schedule(&b) }.to yield_control }
+    end
+
+    context 'with lock acquired by another job' do
+      before { allow(job).to receive(:lock!).and_raise(Cloudtasker::UniqueJob::LockError) }
+      before { allow(lock.conflict_instance).to receive(:on_schedule) }
+      after { expect(lock.conflict_instance).to have_received(:on_schedule) { |&b| expect(b).to be_a(Proc) } }
+      it { expect { |b| lock.schedule(&b) }.not_to yield_control }
+    end
+  end
+
+  describe '#execute' do
+    before { allow(job).to receive(:lock!) }
+    before { allow(job).to receive(:unlock!) }
+
+    context 'with lock available and successful execution' do
+      after { expect(job).to have_received(:unlock!) }
+      it { expect { |b| lock.execute(&b) }.to yield_control }
+    end
+
+    context 'with lock acquired by another job' do
+      before { allow(job).to receive(:lock!).and_raise(Cloudtasker::UniqueJob::LockError) }
+      before { allow(lock.conflict_instance).to receive(:on_execute) }
+      after { expect(lock.conflict_instance).to have_received(:on_execute) { |&b| expect(b).to be_a(Proc) } }
+      after { expect(job).not_to have_received(:unlock!) }
+      it { expect { |b| lock.execute(&b) }.not_to yield_control }
+    end
+
+    context 'with DeadWorkerError' do
+      let(:error) { Cloudtasker::DeadWorkerError }
+      let(:block) { proc { raise(error) } }
+
+      after { expect(job).to have_received(:unlock!) }
+      it { expect { lock.execute(&block) }.to raise_error(error) }
+    end
+
+    context 'with runtime error (not DeadWorkerError)' do
+      let(:error) { ArgumentError }
+      let(:block) { proc { raise(error) } }
+
+      after { expect(job).not_to have_received(:unlock!) }
+      it { expect { lock.execute(&block) }.to raise_error(error) }
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the UntilCompleted lock strategy to the unique job locking mechanism in Cloudtasker. The lock is only released upon successful completion or when a DeadWorkerError is raised.