### PR TITLE
Fix unique-job lock leak in inline testing mode

### DIFF
--- a/lib/cloudtasker/unique_job/job.rb
+++ b/lib/cloudtasker/unique_job/job.rb
@@ -230,18 +230,14 @@ module Cloudtasker
         # Step 2: Yield to perform scheduling operation
         result = yield
 
-        # Step 3: Set final lock
-        # Check if the lock is still held by this job
-        acquired = redis.get(unique_gid) == id
-
-        # Set the lock with final duration
-        # If already acquired, refresh with final TTL
-        # If not acquired (expired or taken), try to acquire exclusively
-        final_lock_acquired = redis.set(unique_gid, id, nx: !acquired, ex: lock_ttl)
-
-        # Log a warning if final lock could not be acquired
-        # The job has already been enqueued at this point, so raising an error is useless
-        worker.logger.warn(LOCK_FINALIZATION_WARNING) unless final_lock_acquired
+        # Step 3: Promote the provisional lock to the final lock
+        #
+        # Skipped under inline execution (testing): in that mode the job runs
+        # synchronously within the yield above and releases its own lock via the
+        # execute middleware. Re-acquiring the lock here would resurrect a lock
+        # that nothing will ever release, wrongly rejecting subsequent enqueues
+        # of the same unique job.
+        set_final_lock! unless inline_mode?
 
         # Return the result of the block
         result
@@ -253,6 +249,36 @@ module Cloudtasker
       def unlock!
         locked_id = redis.get(unique_gid)
         redis.del(unique_gid) if locked_id == id
+      end
+
+      private
+
+      #
+      # Promote the provisional lock to the full lock TTL after the job has been
+      # enqueued. The job is already enqueued at this point, so a failure to
+      # acquire is logged rather than raised.
+      #
+      def set_final_lock!
+        # Check if the lock is still held by this job
+        acquired = redis.get(unique_gid) == id
+
+        # Set the lock with final duration
+        # If already acquired, refresh with final TTL
+        # If not acquired (expired or taken), try to acquire exclusively
+        final_lock_acquired = redis.set(unique_gid, id, nx: !acquired, ex: lock_ttl)
+
+        # Log a warning if final lock could not be acquired
+        worker.logger.warn(LOCK_FINALIZATION_WARNING) unless final_lock_acquired
+      end
+
+      #
+      # Return true in inline testing mode, where jobs run synchronously at
+      # enqueue time. Mirrors `Backend::MemoryTask.inline_mode?`.
+      #
+      # @return [Boolean] True if inline mode enabled.
+      #
+      def inline_mode?
+        defined?(Cloudtasker::Testing) && Cloudtasker::Testing.inline?
       end
     end
   end

--- a/spec/cloudtasker/unique_job/job_spec.rb
+++ b/spec/cloudtasker/unique_job/job_spec.rb
@@ -378,6 +378,20 @@ RSpec.describe Cloudtasker::UniqueJob::Job do
         expect(job.redis.ttl(job.unique_gid)).to be_within(2).of(job.lock_provisional_ttl)
       end
     end
+
+    context 'with inline execution mode' do
+      # In inline mode the job runs synchronously within the yield and releases
+      # its own lock, so the final lock must not be re-acquired (nothing would
+      # release it). The TTL therefore stays at the short provisional value.
+      it 'does not promote the lock to the final TTL' do
+        Cloudtasker::Testing.inline! do
+          job.lock_for_scheduling! { block_executed << true }
+        end
+
+        expect(block_executed).to eq([true])
+        expect(job.redis.ttl(job.unique_gid)).to be_within(2).of(job.lock_provisional_ttl)
+      end
+    end
   end
 
   describe '#unlock!' do

--- a/spec/integration/inline_execution_spec.rb
+++ b/spec/integration/inline_execution_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'cloudtasker/batch/middleware'
+
+# Contract for Cloudtasker::Testing.inline!: within an inline! block a job runs
+# as the real server would. That holds because inline execution happens in
+# Backend::MemoryTask.create — the single point through which all enqueue paths
+# funnel — and from there goes through WorkerHandler.with_worker_handling.
+#
+# These specs pin three consequences of that, only some of which are covered
+# elsewhere (e.g. the batch integration spec drains a fake! queue manually
+# rather than running inline!):
+#
+#   1. Execution coverage — every enqueue path runs (perform_async,
+#      perform_at/perform_in, the instance #schedule method, batch children).
+#   2. Error hooks — a raising job fires the on_error hook.
+#   3. Context fidelity — the worker runs with a task_id.
+RSpec.describe 'Testing.inline! server-path fidelity' do
+  before { TestWorker.has_run = false }
+
+  # Control: .perform_async is the one path most inline handling focuses on.
+  describe '.perform_async' do
+    it 'runs the job inline' do
+      Cloudtasker::Testing.inline! { TestWorker.perform_async(2, 3) }
+      expect(TestWorker.has_run).to be(true)
+    end
+  end
+
+  # Scheduled jobs must still run immediately in inline mode — the delay/eta is
+  # ignored, exactly as with an immediately-enqueued job.
+  describe '.perform_in' do
+    it 'runs the scheduled job inline despite the delay' do
+      Cloudtasker::Testing.inline! { TestWorker.perform_in(60, 2, 3) }
+      expect(TestWorker.has_run).to be(true)
+    end
+  end
+
+  describe '.perform_at' do
+    it 'runs the scheduled job inline despite the schedule time' do
+      Cloudtasker::Testing.inline! { TestWorker.perform_at(Time.now + 3600, 2, 3) }
+      expect(TestWorker.has_run).to be(true)
+    end
+  end
+
+  # Jobs enqueued through the instance #schedule method — the path used by batch
+  # children — must also run inline.
+  describe '#schedule' do
+    it 'runs the job inline' do
+      Cloudtasker::Testing.inline! { TestWorker.new(job_args: [2, 3]).schedule }
+      expect(TestWorker.has_run).to be(true)
+    end
+  end
+
+  # Batch children are enqueued via #schedule (not .perform_async), so an inline!
+  # batch must run the parent AND every child synchronously. We assert on child
+  # execution only (not completion callbacks) to stay orthogonal to batch
+  # completion semantics.
+  describe 'batch children' do
+    before { Cloudtasker::Batch::Middleware.configure }
+    before { TestInlineBatchWorker.runs = nil }
+
+    it 'runs the parent and all children inline' do
+      Cloudtasker::Testing.inline! { TestInlineBatchWorker.perform_async }
+
+      # Parent (level 0) plus CHILD_COUNT children (level 1).
+      expect(TestInlineBatchWorker.runs.sort).to eq([0, 1, 1, 1])
+    end
+  end
+
+  # An inline job that raises must still be routed through
+  # WorkerHandler.with_worker_handling, so the on_error / on_dead hooks fire
+  # exactly as they do on the real server. A refactor that executes the worker
+  # directly (bypassing with_worker_handling) silently drops these hooks even
+  # though the job itself still runs.
+  describe 'error handling hooks' do
+    before { TestErrorWorker.has_run = false }
+
+    it 'invokes the on_error hook when an inline job raises' do
+      reported = []
+      allow(Cloudtasker.config).to receive(:on_error).and_return(->(error, worker) { reported << [error, worker] })
+
+      expect do
+        Cloudtasker::Testing.inline! { TestErrorWorker.perform_async(true) }
+      end.to raise_error(StandardError, 'test error')
+
+      expect(TestErrorWorker.has_run).to be(true)
+      expect(reported.size).to eq(1)
+      expect(reported.first.first).to be_a(StandardError)
+    end
+  end
+
+  # Inline execution should reproduce the server execution context — including a
+  # task_id, which applications read for logging and error instrumentation. A
+  # refactor that runs the worker straight from its args (without the backend's
+  # task assignment) leaves task_id nil and silently degrades that context.
+  describe 'execution context' do
+    before { TestContextWorker.last_task_id = nil }
+
+    it 'runs the inline job with a task_id, like the server path' do
+      Cloudtasker::Testing.inline! { TestContextWorker.perform_async }
+
+      expect(TestContextWorker.last_task_id).not_to be_nil
+    end
+  end
+end

--- a/spec/integration/unique_job_spec.rb
+++ b/spec/integration/unique_job_spec.rb
@@ -65,6 +65,22 @@ RSpec.describe 'Unique Worker' do
     end
   end
 
+  describe 'successive inline enqueuing+run of standalone jobs with same args' do
+    before do
+      Cloudtasker::Testing.inline! do
+        TestUniqueJobWorker.perform_async(1, 2)
+        TestUniqueJobWorker.perform_async(1, 2)
+      end
+    end
+
+    # In inline mode the job runs synchronously within the enqueue call and
+    # releases its lock. A second enqueue of the same unique job must therefore
+    # run again rather than being rejected by a lock left behind by the first.
+    it 'processes both jobs' do
+      expect(TestUniqueJobWorker.past_job_args).to eq([[1, 2], [1, 2]])
+    end
+  end
+
   describe 'concurrent enqueuing of a standalone job and batch sub-job (lock_per_batch: true)' do
     before do
       orig_options = TestUniqueJobWorker.cloudtasker_options_hash

--- a/spec/support/test_context_worker.rb
+++ b/spec/support/test_context_worker.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Records the execution context (task_id) seen inside #perform, so specs can
+# assert that an inline-executed job carries the same context as the real
+# server path (where the backend assigns a task_id).
+class TestContextWorker
+  include Cloudtasker::Worker
+
+  class << self
+    attr_accessor :last_task_id
+  end
+
+  def perform
+    self.class.last_task_id = task_id
+  end
+end

--- a/spec/support/test_inline_batch_worker.rb
+++ b/spec/support/test_inline_batch_worker.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Minimal batch worker used to exercise Cloudtasker::Testing.inline! execution.
+#
+# The parent (level 0) enqueues CHILD_COUNT children; each run appends its level
+# to a class-level registry so specs can assert that batch children execute
+# synchronously in inline mode. Children (level 1) add no further jobs.
+class TestInlineBatchWorker
+  include Cloudtasker::Worker
+
+  CHILD_COUNT = 3
+
+  class << self
+    attr_accessor :runs
+  end
+
+  def perform(level = 0)
+    self.class.runs ||= []
+    self.class.runs << level.to_i
+
+    CHILD_COUNT.times { batch.add(self.class, 1) } if level.to_i.zero?
+  end
+end


### PR DESCRIPTION
## Problem

In inline mode (`Cloudtasker::Testing.inline!`), a unique job runs only the first time it's enqueued — later enqueues of the same job are silently rejected.

`lock_for_scheduling!` (added in 0.15.0) takes a provisional lock, yields to enqueue the job, then takes the final lock. That final lock is meant to be released later, when the job runs — the execute middleware unlocks it.

But in inline mode the job runs *during* the yield, so it unlocks before the final lock is even taken. The final lock is then set after the job has already finished, leaving it with no future run to release it. It lingers for the full `lock_ttl` and rejects later enqueues of the same job (`on_conflict: :reject`). 0.14.0 did a plain `lock!; yield`, so this is a regression.

```ruby
Cloudtasker::Testing.inline! do
  TestUniqueJobWorker.perform_async(1, 2)
  TestUniqueJobWorker.perform_async(1, 2)
end
# before: [[1, 2]]            (second rejected)
# after:  [[1, 2], [1, 2]]
```

## Fix

Skip the final-lock step in inline mode, where the job has already run and released its lock. The async/production path is unchanged: `inline_mode?` is guarded by `defined?(Cloudtasker::Testing)`, which is false in production (same idiom as `CloudTask.backend` and `Backend::MemoryTask.inline_mode?`).

## Tests

Integration spec (both inline enqueues run) and unit spec (lock not promoted to the final TTL).