### PR TITLE
Prevent on_batch_complete from firing before all children are enqueued

### DIFF
--- a/lib/cloudtasker/batch/job.rb
+++ b/lib/cloudtasker/batch/job.rb
@@ -207,6 +207,16 @@ module Cloudtasker
       end
 
       #
+      # Return the key used to flag that the parent has finished enqueuing all
+      # children of the batch.
+      #
+      # @return [String] The batch setup-complete key.
+      #
+      def batch_setup_gid
+        "#{batch_state_gid}/setup_complete"
+      end
+
+      #
       # Return the number of jobs in a given state
       #
       # @return [String] The batch progress state namespaced id.
@@ -372,6 +382,22 @@ module Cloudtasker
       end
 
       #
+      # Return true once the parent has finished enqueuing all children of the
+      # batch (end of #setup).
+      #
+      # Completion must not be evaluated before this point: the parent enqueues
+      # children one at a time, so a fast child can complete while later siblings
+      # have not yet been scheduled or registered. Without this gate, `complete?`
+      # would see only the children registered so far and report the batch done,
+      # firing `on_batch_complete` prematurely.
+      #
+      # @return [Boolean] True if the batch has been fully enqueued.
+      #
+      def setup_complete?
+        redis.exists?(batch_setup_gid)
+      end
+
+      #
       # Run worker callback. The error and dead callbacks get
       # silenced should they raise an error.
       #
@@ -436,6 +462,11 @@ module Cloudtasker
         return if status == :errored
         return unless complete?
 
+        # Do not let a child complete the batch until the parent has finished
+        # enqueuing every child. Otherwise a fast child can fire on_complete
+        # before its slower siblings have even been scheduled. See #setup_complete?.
+        return unless setup_complete?
+
         # Notify the parent batch that we are done with this batch. Use SETNX to ensure
         # only the first concurrent child to complete triggers on_complete.
         return unless redis.set(batch_completion_gid, true, nx: true, ex: BATCH_COMPLETION_TTL)
@@ -480,6 +511,7 @@ module Cloudtasker
           m.del(batch_gid)
           m.del(batch_state_gid)
           m.del(batch_completion_gid)
+          m.del(batch_setup_gid)
           BATCH_STATUSES.each { |e| m.del(batch_state_count_gid(e)) }
         end
       end
@@ -553,6 +585,11 @@ module Cloudtasker
 
         # Schedule all child workers
         schedule_pending_jobs
+
+        # Flag the batch as fully enqueued. Until this is set, a child that
+        # completes must not be allowed to trigger batch completion — see
+        # #setup_complete?.
+        redis.set(batch_setup_gid, true)
       end
 
       #

--- a/lib/cloudtasker/batch/job.rb
+++ b/lib/cloudtasker/batch/job.rb
@@ -207,10 +207,10 @@ module Cloudtasker
       end
 
       #
-      # Return the key used to flag that the parent has finished enqueuing all
-      # children of the batch.
+      # Return the key tracking the batch enqueuing lifecycle: 'in_progress'
+      # while the parent enqueues children, 'done' once finished.
       #
-      # @return [String] The batch setup-complete key.
+      # @return [String] The batch setup marker key.
       #
       def batch_setup_gid
         "#{batch_state_gid}/setup_complete"
@@ -382,19 +382,19 @@ module Cloudtasker
       end
 
       #
-      # Return true once the parent has finished enqueuing all children of the
-      # batch (end of #setup).
+      # Return true unless the parent is still enqueuing children. The parent
+      # enqueues one at a time, so a fast child could otherwise complete off a
+      # partially-registered state and fire `on_batch_complete` prematurely
+      # (see #on_child_complete).
       #
-      # Completion must not be evaluated before this point: the parent enqueues
-      # children one at a time, so a fast child can complete while later siblings
-      # have not yet been scheduled or registered. Without this gate, `complete?`
-      # would see only the children registered so far and report the batch done,
-      # firing `on_batch_complete` prematurely.
+      # A batch with no marker predates this feature (enqueued by an older
+      # #setup); treat it as fully enqueued so batches in flight during an
+      # upgrade complete normally instead of being stranded.
       #
-      # @return [Boolean] True if the batch has been fully enqueued.
+      # @return [Boolean] True unless the batch is still enqueuing children.
       #
       def setup_complete?
-        redis.exists?(batch_setup_gid)
+        redis.get(batch_setup_gid) != 'in_progress'
       end
 
       #
@@ -583,13 +583,15 @@ module Cloudtasker
         # Save batch
         save
 
+        # Mark as enqueuing before scheduling any child: while set, a completing
+        # child must not trigger batch completion (see #setup_complete?).
+        redis.set(batch_setup_gid, 'in_progress')
+
         # Schedule all child workers
         schedule_pending_jobs
 
-        # Flag the batch as fully enqueued. Until this is set, a child that
-        # completes must not be allowed to trigger batch completion — see
-        # #setup_complete?.
-        redis.set(batch_setup_gid, true)
+        # Mark as fully enqueued; children may now trigger completion.
+        redis.set(batch_setup_gid, 'done')
       end
 
       #

--- a/spec/cloudtasker/batch/job_spec.rb
+++ b/spec/cloudtasker/batch/job_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe Cloudtasker::Batch::Job do
         expect(child_worker).not_to receive(:schedule)
       end
 
-      after { expect(batch).not_to be_setup_complete }
+      after { expect(redis.get(batch.batch_setup_gid)).to be_nil }
       it { is_expected.to be_truthy }
     end
 
@@ -400,7 +400,7 @@ RSpec.describe Cloudtasker::Batch::Job do
         expect(batch).to receive(:schedule_pending_jobs).and_return(true)
       end
 
-      after { expect(batch).to be_setup_complete }
+      after { expect(redis.get(batch.batch_setup_gid)).to eq('done') }
       it { is_expected.to be_truthy }
     end
   end
@@ -408,22 +408,30 @@ RSpec.describe Cloudtasker::Batch::Job do
   describe '#setup_complete?' do
     subject { batch }
 
-    context 'without the batch having been enqueued' do
+    context 'when the batch is still enqueuing children' do
+      before { redis.set(batch.batch_setup_gid, 'in_progress') }
+
       it { is_expected.not_to be_setup_complete }
     end
 
-    context 'with the batch flagged as fully enqueued' do
-      before { redis.set(batch.batch_setup_gid, true) }
+    context 'when the batch is fully enqueued' do
+      before { redis.set(batch.batch_setup_gid, 'done') }
 
+      it { is_expected.to be_setup_complete }
+    end
+
+    context 'without a marker (batch enqueued before this feature)' do
+      # Backward compatibility: batches in flight during an upgrade have no
+      # marker and must be treated as fully enqueued so they are not stranded.
       it { is_expected.to be_setup_complete }
     end
   end
 
   describe 'progressive batch expansion' do
     # A running child may add more jobs to a batch that has already been set up
-    # (see docs/BATCH_JOBS.md "Expanding the parent batch"). The setup seal is
-    # set once at the initial setup and must not interfere: the batch stays open
-    # while the expanding child runs, then completes normally.
+    # (see docs/BATCH_JOBS.md "Expanding the parent batch"). The setup marker is
+    # written during the initial enqueue and must not interfere: the batch stays
+    # open while the expanding child runs, then completes normally.
     let(:initial_child) { worker.new_instance }
     let(:added_child) { worker.new_instance }
 
@@ -431,7 +439,7 @@ RSpec.describe Cloudtasker::Batch::Job do
       allow_any_instance_of(Cloudtasker::Worker).to receive(:schedule)
         .and_return(instance_double(Cloudtasker::CloudTask))
 
-      # Parent sets up with one initial child and seals the batch
+      # Parent sets up with one initial child and marks the batch enqueued
       batch.pending_jobs.push(initial_child)
       batch.setup
 
@@ -459,6 +467,25 @@ RSpec.describe Cloudtasker::Batch::Job do
 
       it { expect(batch).to be_complete }
       it { expect(batch).to be_setup_complete }
+    end
+  end
+
+  describe 'batch enqueued before the setup marker (upgrade in flight)' do
+    # A batch enqueued by a previous version has no setup marker. After an
+    # upgrade its remaining children must still be able to complete it - the
+    # parent already ran under the old code and cannot act as the fallback -
+    # otherwise the batch would be stranded and on_batch_complete never fire.
+    before do
+      batch.save
+      redis.hset(batch.batch_state_gid, child_batch.batch_id, 'processing')
+    end
+
+    it { expect(redis.get(batch.batch_setup_gid)).to be_nil }
+    it { expect(batch).to be_setup_complete }
+
+    it 'lets the final child complete the batch' do
+      expect(batch).to receive(:on_complete)
+      batch.on_child_complete(child_batch, :completed)
     end
   end
 

--- a/spec/cloudtasker/batch/job_spec.rb
+++ b/spec/cloudtasker/batch/job_spec.rb
@@ -419,6 +419,49 @@ RSpec.describe Cloudtasker::Batch::Job do
     end
   end
 
+  describe 'progressive batch expansion' do
+    # A running child may add more jobs to a batch that has already been set up
+    # (see docs/BATCH_JOBS.md "Expanding the parent batch"). The setup seal is
+    # set once at the initial setup and must not interfere: the batch stays open
+    # while the expanding child runs, then completes normally.
+    let(:initial_child) { worker.new_instance }
+    let(:added_child) { worker.new_instance }
+
+    before do
+      allow_any_instance_of(Cloudtasker::Worker).to receive(:schedule)
+        .and_return(instance_double(Cloudtasker::CloudTask))
+
+      # Parent sets up with one initial child and seals the batch
+      batch.pending_jobs.push(initial_child)
+      batch.setup
+
+      # The initial child starts running, then expands the batch before completing
+      batch.update_state(initial_child.job_id, 'processing')
+      batch.pending_jobs.push(added_child)
+      batch.schedule_pending_jobs
+    end
+
+    it { expect(batch).to be_setup_complete }
+
+    context 'with the expanding child still running' do
+      before { batch.update_state(added_child.job_id, 'completed') }
+
+      # The expanding child's own 'processing' entry holds the batch open, so
+      # the freshly added child completing does not complete the batch.
+      it { expect(batch).not_to be_complete }
+    end
+
+    context 'with the expanding child and the added child both completed' do
+      before do
+        batch.update_state(added_child.job_id, 'completed')
+        batch.update_state(initial_child.job_id, 'completed')
+      end
+
+      it { expect(batch).to be_complete }
+      it { expect(batch).to be_setup_complete }
+    end
+  end
+
   describe '#update_state' do
     subject { batch.batch_state&.dig(child_id) }
 

--- a/spec/cloudtasker/batch/job_spec.rb
+++ b/spec/cloudtasker/batch/job_spec.rb
@@ -388,6 +388,7 @@ RSpec.describe Cloudtasker::Batch::Job do
         expect(child_worker).not_to receive(:schedule)
       end
 
+      after { expect(batch).not_to be_setup_complete }
       it { is_expected.to be_truthy }
     end
 
@@ -399,7 +400,22 @@ RSpec.describe Cloudtasker::Batch::Job do
         expect(batch).to receive(:schedule_pending_jobs).and_return(true)
       end
 
+      after { expect(batch).to be_setup_complete }
       it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#setup_complete?' do
+    subject { batch }
+
+    context 'without the batch having been enqueued' do
+      it { is_expected.not_to be_setup_complete }
+    end
+
+    context 'with the batch flagged as fully enqueued' do
+      before { redis.set(batch.batch_setup_gid, true) }
+
+      it { is_expected.to be_setup_complete }
     end
   end
 
@@ -592,7 +608,7 @@ RSpec.describe Cloudtasker::Batch::Job do
     let(:complete) { true }
 
     before do
-      allow(batch).to receive_messages(complete?: complete, on_complete: true)
+      allow(batch).to receive_messages(complete?: complete, on_complete: true, setup_complete?: true)
       allow(batch).to receive(:update_state).with(child_batch.batch_id, status)
       allow(batch).to receive(:run_worker_callback)
       batch.pending_jobs.push(child_worker)
@@ -610,6 +626,15 @@ RSpec.describe Cloudtasker::Batch::Job do
       after { expect(batch).to have_received(:run_worker_callback).with(:on_child_complete, child_batch.worker) }
       after { expect(batch).to have_received(:on_complete) }
       it { is_expected.to be_truthy }
+    end
+
+    context 'with batch complete but the parent still enqueuing children' do
+      before { allow(batch).to receive(:setup_complete?).and_return(false) }
+
+      after { expect(batch).to have_received(:update_state) }
+      after { expect(batch).to have_received(:run_worker_callback).with(:on_child_complete, child_batch.worker) }
+      after { expect(batch).not_to have_received(:on_complete) }
+      it { is_expected.to be_falsey }
     end
 
     context 'with batch complete but completion already claimed by another child' do
@@ -708,6 +733,7 @@ RSpec.describe Cloudtasker::Batch::Job do
       [
         side_batch.batch_gid,
         side_batch.batch_state_gid,
+        side_batch.batch_setup_gid,
         side_batch.batch_state_count_gid('all'),
         side_batch.batch_state_count_gid('scheduled')
       ].sort


### PR DESCRIPTION
## The bug

`on_batch_complete` can fire **before the batch has finished enqueuing its children**.

The parent enqueues children one at a time, and `complete?` only checks the children already registered in the batch state — it has no notion of how many there will ultimately be. On a large fan-out, an early child can finish before the parent has registered the rest; at that point, if every child the batch knows about is complete, `complete?` returns `true` and completion fires while later children are still unscheduled.

We hit this in production: a ~300-child batch fired `on_batch_complete` while still enqueuing, and the summary it produced was missing the results the not-yet-run children went on to write.

## The fix

Mark the batch while `setup` is enqueuing children, and require enqueuing to be finished before a child can trigger completion:

- `setup` marks `batch_setup_gid` `in_progress` before scheduling and `done` after.
- `on_child_complete` returns early unless `setup_complete?`.
- `cleanup` removes the key.

Only the child-driven path is gated. A batch whose children all finish *during* enqueuing still completes via the parent's own `complete` at the end of `execute`, so no completion is lost. This is separate from the existing `batch_completion_gid` guard, which dedupes concurrent finishers on an already-enqueued batch.

Progressive batch expansion is unaffected: the marker is written during the initial `setup`, and an expanding child sits in the batch state as `processing`, so `complete?` stays false while it runs.

**One edge case:** if the root fails `setup` on every retry until it's marked dead, the batch has registered children but its marker never reaches `done`, so it never resolves. This only affects a batch whose root died before it could finish enqueuing; on `master` the same case instead fires `on_batch_complete` off the partial set, reporting a never-assembled batch as complete.

### Backward compatibility

`setup` marks a batch `in_progress` while it enqueues children and `done` once finished; the gate only holds a batch back while it's `in_progress`. A batch enqueued before this change has no marker, so it's treated as fully enqueued and completes normally.

## Testing

Added a spec reproducing the premature fire (written to fail on `master`), plus coverage for `setup_complete?`, the `setup` marker, `cleanup` removal, and a batch enqueued before this change (upgrade in flight).
