### PR TITLE
Use perform_now in test inline! mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.15.1](https://github.com/keypup-io/cloudtasker/tree/v0.15.1) (Not released)
+
+[Full Changelog](https://github.com/keypup-io/cloudtasker/compare/v0.15.0...v0.15.1)
+
+**Fixed bugs:**
+- Worker: make `perform_now` go through the full lifecycle of client (+ server) middlewares and worker handling logic (e.g. global `on_error` callbacks) to be in line enqueued workers
+- Testing: make the `inline!` mode use `perform_now`. This fixes an issue where server middlewares were called inside client middlewares, leaving dangling locks as a result.
+
 ## [v0.15.0](https://github.com/keypup-io/cloudtasker/tree/v0.15.0) (2026-06-26)
 
 [Full Changelog](https://github.com/keypup-io/cloudtasker/compare/v0.14.0...v0.15.0)

--- a/lib/cloudtasker/backend/memory_task.rb
+++ b/lib/cloudtasker/backend/memory_task.rb
@@ -9,15 +9,6 @@ module Cloudtasker
       attr_reader :id, :http_request, :schedule_time, :queue
 
       #
-      # Return true if we are in test inline execution mode.
-      #
-      # @return [Boolean] True if inline mode enabled.
-      #
-      def self.inline_mode?
-        defined?(Cloudtasker::Testing) && Cloudtasker::Testing.inline?
-      end
-
-      #
       # Return true if errors must be raised immediately
       #
       # @return [Boolean] True if raise error mode is enabled.
@@ -78,9 +69,7 @@ module Cloudtasker
         task = new(**payload, id: id)
         queue << task
 
-        # Execute task immediately if in testing and inline mode enabled
-        task.execute if inline_mode?
-
+        # Return the task
         task
       end
 

--- a/lib/cloudtasker/middleware/chain.rb
+++ b/lib/cloudtasker/middleware/chain.rb
@@ -207,13 +207,13 @@ module Cloudtasker
       #
       # @param [Array<any>] *args The args to pass to each middleware.
       #
-      def invoke(*args)
-        return yield if empty?
+      def invoke(*args, &block)
+        return block&.call if empty?
 
         chain = retrieve.dup
         traverse_chain = lambda do
           if chain.empty?
-            yield
+            block&.call
           else
             chain.shift.call(*args, &traverse_chain)
           end

--- a/lib/cloudtasker/worker.rb
+++ b/lib/cloudtasker/worker.rb
@@ -106,7 +106,14 @@ module Cloudtasker
       # @return [Cloudtasker::CloudTask] The Google Task response
       #
       def perform_async(*args)
-        schedule(args: args)
+        if defined?(Cloudtasker::Testing) && Cloudtasker::Testing.inline?
+          # In inline testing mode we process the job immediately without
+          # enqueuing it on the backend. Client/Server middlewares run as expected.
+          perform_now(*args)
+        else
+          # Normal flow. Enqueue the job on the backend.
+          schedule(args: args)
+        end
       end
 
       #

--- a/lib/cloudtasker/worker.rb
+++ b/lib/cloudtasker/worker.rb
@@ -106,14 +106,7 @@ module Cloudtasker
       # @return [Cloudtasker::CloudTask] The Google Task response
       #
       def perform_async(*args)
-        if defined?(Cloudtasker::Testing) && Cloudtasker::Testing.inline?
-          # In inline testing mode we process the job immediately without
-          # enqueuing it on the backend. Client/Server middlewares run as expected.
-          perform_now(*args)
-        else
-          # Normal flow. Enqueue the job on the backend.
-          schedule(args: args)
-        end
+        schedule(args: args)
       end
 
       #
@@ -155,12 +148,8 @@ module Cloudtasker
         job_args = JSON.parse(args.to_json)
         worker = new(job_args: job_args)
 
-        # Invoke client middlewares as if the job was being scheduled.
-        # The job runs inline immediately so there is no scheduling time.
-        Cloudtasker.config.client_middleware.invoke(worker)
-
-        # Execute the job though server middleware
-        worker.execute
+        # Run the job immediately
+        worker.perform_now
       end
 
       #
@@ -303,13 +292,40 @@ module Cloudtasker
     # @return [Cloudtasker::CloudTask, nil] The Google Task response or nil if the job was not scheduled
     #
     def schedule(**args)
-      # Evaluate when to schedule the job
-      time_at = schedule_time(**args)
+      if defined?(Cloudtasker::Testing) && Cloudtasker::Testing.inline?
+        # In inline testing mode we process the job immediately without
+        # enqueuing it on the backend. Client/Server middlewares run as expected.
+        perform_now
+      else
+        # Normal flow. Enqueue the job on the backend.
+        # Evaluate when to schedule the job
+        time_at = schedule_time(**args)
 
-      # Schedule job through client middlewares
-      Cloudtasker.config.client_middleware.invoke(self, time_at: time_at) do
-        WorkerHandler.new(self).schedule(time_at: time_at)
+        # Schedule job through client middlewares
+        Cloudtasker.config.client_middleware.invoke(self, time_at: time_at) do
+          WorkerHandler.new(self).schedule(time_at: time_at)
+        end
       end
+    end
+
+    #
+    # Run the worker immediately, without sending it to the queue for processing.
+    #
+    # Middlewares (unique job, batch etc.) will still be invoked as if the job
+    # had been scheduled.
+    #
+    # @return [Any] The result of the worker perform method.
+    #
+    def perform_now
+      # Invoke client middlewares as if the job was being scheduled
+      Cloudtasker.config.client_middleware.invoke(self)
+
+      # Prepare the processing payload
+      handler = WorkerHandler.new(self)
+      worker_payload = handler.worker_payload.merge(job_attempts: job_attempts || 1, task_id: task_id || job_id)
+
+      # Execute the job as if it had been received by the handler
+      WorkerHandler.execute_from_payload!(worker_payload)
     end
 
     #

--- a/lib/cloudtasker/worker.rb
+++ b/lib/cloudtasker/worker.rb
@@ -146,7 +146,14 @@ module Cloudtasker
       def perform_now(*args)
         # Serialize/deserialize arguments to mimic job enqueueing and produce a similar context
         job_args = JSON.parse(args.to_json)
-        new(job_args: job_args).execute
+        worker = new(job_args: job_args)
+
+        # Invoke client middlewares as if the job was being scheduled.
+        # The job runs inline immediately so there is no scheduling time.
+        Cloudtasker.config.client_middleware.invoke(worker)
+
+        # Execute the job though server middleware
+        worker.execute
       end
 
       #

--- a/spec/cloudtasker/backend/memory_task_spec.rb
+++ b/spec/cloudtasker/backend/memory_task_spec.rb
@@ -47,24 +47,6 @@ RSpec.describe Cloudtasker::Backend::MemoryTask do
 
   before { described_class.clear }
 
-  describe '.inline_mode?' do
-    subject { described_class }
-
-    before { allow(Cloudtasker::Testing).to receive(:inline?).and_return(enabled) }
-
-    context 'with testing inline! mode enabled' do
-      let(:enabled) { true }
-
-      it { is_expected.to be_inline_mode }
-    end
-
-    context 'with testing inline! mode disabled' do
-      let(:enabled) { false }
-
-      it { is_expected.not_to be_inline_mode }
-    end
-  end
-
   describe '.raise_errors?' do
     subject { described_class }
 
@@ -125,27 +107,12 @@ RSpec.describe Cloudtasker::Backend::MemoryTask do
 
     let(:create_task) { described_class.create(job_payload.merge(id: task_id)) }
 
-    context 'without inline_mode' do
-      let(:expected_attrs) do
-        job_payload.merge(id: task_id, schedule_time: Time.at(job_payload[:schedule_time]))
-      end
-
-      before { create_task }
-      it { is_expected.to have_attributes(expected_attrs) }
+    let(:expected_attrs) do
+      job_payload.merge(id: task_id, schedule_time: Time.at(job_payload[:schedule_time]))
     end
 
-    context 'with inline_mode' do
-      let(:task) { instance_double(described_class, id: task_id) }
-      let(:expected_attrs) { job_payload.merge(id: task_id) }
-
-      before do
-        allow(described_class).to receive(:inline_mode?).and_return(true)
-        allow(described_class).to receive(:new).with(expected_attrs).and_return(task)
-        expect(task).to receive(:execute)
-        create_task
-      end
-      it { is_expected.to eq(task) }
-    end
+    before { create_task }
+    it { is_expected.to have_attributes(expected_attrs) }
   end
 
   describe '.find' do

--- a/spec/cloudtasker/middleware/chain_spec.rb
+++ b/spec/cloudtasker/middleware/chain_spec.rb
@@ -136,6 +136,11 @@ RSpec.describe Cloudtasker::Middleware::Chain do
       it { expect { |b| chain.invoke(&b) }.to yield_control }
     end
 
+    context 'without chain and no block' do
+      it { expect(chain.invoke).to be_nil }
+      it { expect { chain.invoke }.not_to raise_error }
+    end
+
     context 'with chain' do
       let(:middleware) { TestMiddleware.new }
 
@@ -143,6 +148,16 @@ RSpec.describe Cloudtasker::Middleware::Chain do
       before { allow(chain).to receive(:empty?).and_return(false) }
       after { expect(middleware.called).to be_truthy }
       it { expect { |b| chain.invoke(worker, &b) }.to yield_control }
+    end
+
+    context 'with chain and no block' do
+      let(:middleware) { TestMiddleware.new }
+
+      before { allow(chain).to receive(:retrieve).and_return([middleware]) }
+      before { allow(chain).to receive(:empty?).and_return(false) }
+      after { expect(middleware.called).to be_truthy }
+
+      it { expect { chain.invoke(worker) }.not_to raise_error }
     end
   end
 end

--- a/spec/cloudtasker/worker_spec.rb
+++ b/spec/cloudtasker/worker_spec.rb
@@ -127,28 +127,18 @@ RSpec.describe Cloudtasker::Worker do
   describe '.perform_now' do
     subject { worker_class.perform_now(arg1, arg2) }
 
-    let(:queue) { 'some-queue' }
-    let(:delay) { 10 }
     let(:arg1) { 1 }
     let(:arg2) { { foo: 'bar', some_time: Time.now } }
     let(:job_args) { JSON.parse([arg1, arg2].to_json) }
-    let(:task) { instance_double(Cloudtasker::WorkerHandler) }
     let(:resp) { 'some result' }
     let(:worker) { worker_class.new(job_args: job_args) }
 
     before do
       allow(worker_class).to receive(:new).with(job_args: job_args).and_return(worker)
-      allow(worker).to receive(:execute).and_return(resp)
+      expect(worker).to receive(:perform_now).and_return(resp)
     end
 
     it { is_expected.to eq(resp) }
-
-    context 'with client middleware chain' do
-      before { Cloudtasker.config.client_middleware.add(TestMiddleware) }
-      after { expect(worker.middleware_called).to be_truthy }
-      after { expect(worker.middleware_opts).to be_empty }
-      it { is_expected.to eq(resp) }
-    end
   end
 
   describe '.perform_in' do
@@ -171,15 +161,8 @@ RSpec.describe Cloudtasker::Worker do
     let(:arg2) { 2 }
     let(:resp) { instance_double(Cloudtasker::CloudTask) }
 
-    context 'with regular mode of operation' do
-      before { expect(worker_class).to receive(:schedule).with(args: [arg1, arg2]).and_return(resp) }
-      it { is_expected.to eq(resp) }
-    end
-
-    context 'with inline! testing mode' do
-      before { expect(worker_class).to receive(:perform_now).with(arg1, arg2).and_return(resp) }
-      it { Cloudtasker::Testing.inline! { is_expected.to eq(resp) } }
-    end
+    before { expect(worker_class).to receive(:schedule).with(args: [arg1, arg2]).and_return(resp) }
+    it { is_expected.to eq(resp) }
   end
 
   describe '.schedule' do
@@ -440,20 +423,48 @@ RSpec.describe Cloudtasker::Worker do
     let(:worker) { worker_class.new(job_args: [1, 2]) }
     let(:cal_time_at) { Time.now + 3600 }
 
-    before do
-      allow(worker).to receive(:schedule_time).with(interval: delay, time_at: time_at).and_return(cal_time_at)
-      allow(Cloudtasker::WorkerHandler).to receive(:new).with(worker).and_return(task)
-      allow(task).to receive(:schedule).with(time_at: cal_time_at).and_return(resp)
-    end
+    context 'with production mode' do
+      before do
+        Cloudtasker.config.client_middleware.add(TestMiddleware)
+        allow(worker).to receive(:schedule_time).with(interval: delay, time_at: time_at).and_return(cal_time_at)
+        allow(Cloudtasker::WorkerHandler).to receive(:new).with(worker).and_return(task)
+        expect(task).to receive(:schedule).with(time_at: cal_time_at).and_return(resp)
+      end
+      after do
+        expect(worker.middleware_called).to be_truthy
+        expect(worker.middleware_opts).to eq(time_at: cal_time_at)
+      end
 
-    it { is_expected.to eq(resp) }
-
-    context 'with client middleware chain' do
-      before { Cloudtasker.config.client_middleware.add(TestMiddleware) }
-      after { expect(worker.middleware_called).to be_truthy }
-      after { expect(worker.middleware_opts).to eq(time_at: cal_time_at) }
       it { is_expected.to eq(resp) }
     end
+
+    context 'with inline! testing mode' do
+      before { expect(worker).to receive(:perform_now).and_return(resp) }
+      it { Cloudtasker::Testing.inline! { is_expected.to eq(resp) } }
+    end
+  end
+
+  describe '#perform_now' do
+    subject { worker.perform_now }
+
+    let(:job_args) { [2, 3] }
+    let(:job_id) { 'some-id' }
+    let(:worker) { worker_class.new(job_args: job_args, job_id: job_id) }
+    let(:handler) { instance_double(Cloudtasker::WorkerHandler) }
+    let(:worker_payload) { { worker: worker_class.to_s, job_args: job_args } }
+    let(:expected_payload) { worker_payload.merge(job_attempts: 0, task_id: job_id) }
+    let(:resp) { 'some result' }
+
+    before do
+      Cloudtasker.config.client_middleware.add(TestMiddleware)
+      allow(Cloudtasker::WorkerHandler).to receive(:new).with(worker).and_return(handler)
+      allow(handler).to receive(:worker_payload).and_return(worker_payload)
+      allow(Cloudtasker::WorkerHandler).to receive(:execute_from_payload!)
+        .with(expected_payload).and_return(resp)
+    end
+    after { expect(worker.middleware_called).to be_truthy }
+
+    it { is_expected.to eq(resp) }
   end
 
   describe '#execute' do

--- a/spec/cloudtasker/worker_spec.rb
+++ b/spec/cloudtasker/worker_spec.rb
@@ -171,8 +171,15 @@ RSpec.describe Cloudtasker::Worker do
     let(:arg2) { 2 }
     let(:resp) { instance_double(Cloudtasker::CloudTask) }
 
-    before { allow(worker_class).to receive(:schedule).with(args: [arg1, arg2]).and_return(resp) }
-    it { is_expected.to eq(resp) }
+    context 'with regular mode of operation' do
+      before { expect(worker_class).to receive(:schedule).with(args: [arg1, arg2]).and_return(resp) }
+      it { is_expected.to eq(resp) }
+    end
+
+    context 'with inline! testing mode' do
+      before { expect(worker_class).to receive(:perform_now).with(arg1, arg2).and_return(resp) }
+      it { Cloudtasker::Testing.inline! { is_expected.to eq(resp) } }
+    end
   end
 
   describe '.schedule' do

--- a/spec/cloudtasker/worker_spec.rb
+++ b/spec/cloudtasker/worker_spec.rb
@@ -134,14 +134,21 @@ RSpec.describe Cloudtasker::Worker do
     let(:job_args) { JSON.parse([arg1, arg2].to_json) }
     let(:task) { instance_double(Cloudtasker::WorkerHandler) }
     let(:resp) { 'some result' }
-    let(:worker) { instance_double(worker_class.to_s) }
+    let(:worker) { worker_class.new(job_args: job_args) }
 
     before do
-      expect(worker_class).to receive(:new).with(job_args: job_args).and_return(worker)
-      expect(worker).to receive(:execute).and_return(resp)
+      allow(worker_class).to receive(:new).with(job_args: job_args).and_return(worker)
+      allow(worker).to receive(:execute).and_return(resp)
     end
 
     it { is_expected.to eq(resp) }
+
+    context 'with client middleware chain' do
+      before { Cloudtasker.config.client_middleware.add(TestMiddleware) }
+      after { expect(worker.middleware_called).to be_truthy }
+      after { expect(worker.middleware_opts).to be_empty }
+      it { is_expected.to eq(resp) }
+    end
   end
 
   describe '.perform_in' do

--- a/spec/integration/inline_execution_spec.rb
+++ b/spec/integration/inline_execution_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'cloudtasker/batch/middleware'
+
+# Contract for Cloudtasker::Testing.inline!: within an inline! block a job runs
+# as the real server would. That holds because inline execution happens in
+# Backend::MemoryTask.create — the single point through which all enqueue paths
+# funnel — and from there goes through WorkerHandler.with_worker_handling.
+#
+# These specs pin three consequences of that, only some of which are covered
+# elsewhere (e.g. the batch integration spec drains a fake! queue manually
+# rather than running inline!):
+#
+#   1. Execution coverage — every enqueue path runs (perform_async,
+#      perform_at/perform_in, the instance #schedule method, batch children).
+#   2. Error hooks — a raising job fires the on_error hook.
+#   3. Context fidelity — the worker runs with a task_id.
+RSpec.describe 'Testing.inline! server-path fidelity' do
+  before { TestWorker.has_run = false }
+
+  # Control: .perform_async is the one path most inline handling focuses on.
+  describe '.perform_async' do
+    it 'runs the job inline' do
+      Cloudtasker::Testing.inline! { TestWorker.perform_async(2, 3) }
+      expect(TestWorker.has_run).to be(true)
+    end
+  end
+
+  # Scheduled jobs must still run immediately in inline mode — the delay/eta is
+  # ignored, exactly as with an immediately-enqueued job.
+  describe '.perform_in' do
+    it 'runs the scheduled job inline despite the delay' do
+      Cloudtasker::Testing.inline! { TestWorker.perform_in(60, 2, 3) }
+      expect(TestWorker.has_run).to be(true)
+    end
+  end
+
+  describe '.perform_at' do
+    it 'runs the scheduled job inline despite the schedule time' do
+      Cloudtasker::Testing.inline! { TestWorker.perform_at(Time.now + 3600, 2, 3) }
+      expect(TestWorker.has_run).to be(true)
+    end
+  end
+
+  # Jobs enqueued through the instance #schedule method — the path used by batch
+  # children — must also run inline.
+  describe '#schedule' do
+    it 'runs the job inline' do
+      Cloudtasker::Testing.inline! { TestWorker.new(job_args: [2, 3]).schedule }
+      expect(TestWorker.has_run).to be(true)
+    end
+  end
+
+  # Batch children are enqueued via #schedule (not .perform_async), so an inline!
+  # batch must run the parent AND every child synchronously. We assert on child
+  # execution only (not completion callbacks) to stay orthogonal to batch
+  # completion semantics.
+  describe 'batch children' do
+    before { Cloudtasker::Batch::Middleware.configure }
+    before { TestInlineBatchWorker.runs = nil }
+
+    it 'runs the parent and all children inline' do
+      Cloudtasker::Testing.inline! { TestInlineBatchWorker.perform_async }
+
+      # Parent (level 0) plus CHILD_COUNT children (level 1).
+      expect(TestInlineBatchWorker.runs.sort).to eq([0, 1, 1, 1])
+    end
+  end
+
+  # An inline job that raises must still be routed through
+  # WorkerHandler.with_worker_handling, so the on_error / on_dead hooks fire
+  # exactly as they do on the real server. A refactor that executes the worker
+  # directly (bypassing with_worker_handling) silently drops these hooks even
+  # though the job itself still runs.
+  describe 'error handling hooks' do
+    before { TestErrorWorker.has_run = false }
+
+    it 'invokes the on_error hook when an inline job raises' do
+      reported = []
+      allow(Cloudtasker.config).to receive(:on_error).and_return(->(error, worker) { reported << [error, worker] })
+
+      expect do
+        Cloudtasker::Testing.inline! { TestErrorWorker.perform_async(true) }
+      end.to raise_error(StandardError, 'test error')
+
+      expect(TestErrorWorker.has_run).to be(true)
+      expect(reported.size).to eq(1)
+      expect(reported.first.first).to be_a(StandardError)
+    end
+  end
+
+  # Inline execution should reproduce the server execution context — including a
+  # task_id, which applications read for logging and error instrumentation. A
+  # refactor that runs the worker straight from its args (without the backend's
+  # task assignment) leaves task_id nil and silently degrades that context.
+  describe 'execution context' do
+    before { TestContextWorker.last_task_id = nil }
+
+    it 'runs the inline job with a task_id, like the server path' do
+      Cloudtasker::Testing.inline! { TestContextWorker.perform_async }
+
+      expect(TestContextWorker.last_task_id).not_to be_nil
+    end
+  end
+end

--- a/spec/integration/unique_job_spec.rb
+++ b/spec/integration/unique_job_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe 'Unique Worker' do
     end
   end
 
+  describe 'successive inline enqueuing+run of standalone jobs with same args' do
+    before do
+      Cloudtasker::Testing.inline! do
+        TestUniqueJobWorker.perform_async(1, 2)
+        TestUniqueJobWorker.perform_async(1, 2)
+      end
+    end
+
+    # In inline mode the job runs synchronously within the enqueue call and
+    # releases its lock. A second enqueue of the same unique job must therefore
+    # run again rather than being rejected by a lock left behind by the first.
+    it { expect(TestUniqueJobWorker.past_job_args).to eq([[1, 2], [1, 2]]) }
+  end
+
   describe 'concurrent enqueuing of a standalone job and batch sub-job (lock_per_batch: true)' do
     before do
       orig_options = TestUniqueJobWorker.cloudtasker_options_hash

--- a/spec/support/test_context_worker.rb
+++ b/spec/support/test_context_worker.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Records the execution context (task_id) seen inside #perform, so specs can
+# assert that an inline-executed job carries the same context as the real
+# server path (where the backend assigns a task_id).
+class TestContextWorker
+  include Cloudtasker::Worker
+
+  class << self
+    attr_accessor :last_task_id
+  end
+
+  def perform
+    self.class.last_task_id = task_id
+  end
+end

--- a/spec/support/test_inline_batch_worker.rb
+++ b/spec/support/test_inline_batch_worker.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Minimal batch worker used to exercise Cloudtasker::Testing.inline! execution.
+#
+# The parent (level 0) enqueues CHILD_COUNT children; each run appends its level
+# to a class-level registry so specs can assert that batch children execute
+# synchronously in inline mode. Children (level 1) add no further jobs.
+class TestInlineBatchWorker
+  include Cloudtasker::Worker
+
+  CHILD_COUNT = 3
+
+  class << self
+    attr_accessor :runs
+  end
+
+  def perform(level = 0)
+    self.class.runs ||= []
+    self.class.runs << level.to_i
+
+    CHILD_COUNT.times { batch.add(self.class, 1) } if level.to_i.zero?
+  end
+end


### PR DESCRIPTION
Originally raised in: https://github.com/keypup-io/cloudtasker/pull/173

The test `inline!` mode is expected to run jobs immediately. The problem is that this immediate execution is implemented in the create task action on the backend (MemoryTask), which is invoked while enqueuing the job.

Since the job is executed while being enqueued, the server middlewares run inside the client middlewares. This means the client middleware may leave dangling locks that the server middlewares would normally clean, thus preventing successive jobs from running in the case of the `unique_job` extension.

Here is a typical example:
```ruby
Cloudtasker::Testing.inline! do
  TestUniqueJobWorker.perform_async(1, 2)
  TestUniqueJobWorker.perform_async(1, 2)
end
# Actual: [[1, 2]]            (second job is rejected due to dangling locks)
# Expected:  [[1, 2], [1, 2]]
```

This PR addresses this issue by doing the following:
1. Ensure `perform_now` runs the client middlewares on top of the server middlewares. This ensures the full worker lifecycle is respected.
2. Stop implementing the `inline!` execution in the create action of the backend (MemoryTask)
3. Instead, rewire `perform_async` to `perform_now` when test `inline!` mode is enabled