### PR TITLE
Dedupe batch completion across both code paths

### DIFF
--- a/lib/cloudtasker/batch/job.rb
+++ b/lib/cloudtasker/batch/job.rb
@@ -415,6 +415,29 @@ module Cloudtasker
       end
 
       #
+      # Fire the batch completion callback, letting only the first path through.
+      #
+      # The last child (#on_child_complete) and the parent's own backstop
+      # (#complete) can observe the batch as complete at the same time; the SETNX
+      # guard lets only the first of them fire on_complete.
+      #
+      # @param [Symbol] status The completion status to propagate.
+      #
+      # @return [Boolean, nil] Truthy if this path triggered completion.
+      #
+      def trigger_completion(status = :completed)
+        return unless redis.set(batch_completion_gid, true, nx: true, ex: BATCH_COMPLETION_TTL)
+
+        begin
+          on_complete(status)
+        rescue StandardError
+          # Clear the key on error so completion can be reattempted
+          redis.del(batch_completion_gid)
+          raise
+        end
+      end
+
+      #
       # Callback invoked when a direct child batch is complete.
       #
       # @param [Cloudtasker::Batch::Job] child_batch The completed child batch.
@@ -436,19 +459,8 @@ module Cloudtasker
         return if status == :errored
         return unless complete?
 
-        # Notify the parent batch that we are done with this batch. Use SETNX to ensure
-        # only the first concurrent child to complete triggers on_complete.
-        return unless redis.set(batch_completion_gid, true, nx: true, ex: BATCH_COMPLETION_TTL)
-
-        begin
-          on_complete
-        rescue StandardError
-          # Clear key on error so completion can be reattempted
-          redis.del(batch_completion_gid)
-
-          # Re-raise
-          raise
-        end
+        # Every child is done: fire completion through the shared SETNX guard.
+        trigger_completion
       end
 
       #
@@ -561,8 +573,10 @@ module Cloudtasker
       def complete(status = :completed)
         return true if reenqueued?
 
-        # Notify the parent batch that a child is complete
-        on_complete(status) if complete?
+        # Fire completion if all children are done. Goes through the same SETNX
+        # guard as #on_child_complete so this backstop and a concurrent child
+        # don't both fire.
+        trigger_completion(status) if complete?
 
         # Notify the parent that a batch node has completed
         parent_batch&.on_batch_node_complete(self, status)

--- a/spec/cloudtasker/batch/job_spec.rb
+++ b/spec/cloudtasker/batch/job_spec.rb
@@ -585,6 +585,50 @@ RSpec.describe Cloudtasker::Batch::Job do
     end
   end
 
+  describe '#trigger_completion' do
+    subject(:trigger_completion) { batch.trigger_completion(status) }
+
+    let(:status) { :completed }
+
+    context 'when no other path has claimed completion' do
+      before { allow(batch).to receive(:on_complete).and_return(true) }
+
+      after { expect(batch).to have_received(:on_complete).with(status) }
+      it { is_expected.to be_truthy }
+    end
+
+    # The parent backstop forwards its own status (e.g. :dead/:errored); only the
+    # child path always fires :completed.
+    context 'when propagating a non-completed status' do
+      let(:status) { :dead }
+
+      before { allow(batch).to receive(:on_complete).and_return(true) }
+
+      after { expect(batch).to have_received(:on_complete).with(:dead) }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when completion was already claimed by another path' do
+      before do
+        allow(batch).to receive(:on_complete)
+        redis.set(batch.batch_completion_gid, true)
+      end
+
+      after { expect(batch).not_to have_received(:on_complete) }
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when on_complete raises' do
+      before { allow(batch).to receive(:on_complete).and_raise(ArgumentError) }
+
+      # Key must be cleared on error so completion can be reattempted.
+      it 'clears the completion key and re-raises' do
+        expect { trigger_completion }.to raise_error(ArgumentError)
+        expect(redis.get(batch.batch_completion_gid)).to be_nil
+      end
+    end
+  end
+
   describe '#on_child_complete' do
     subject { batch.on_child_complete(child_batch, status) }
 
@@ -817,7 +861,31 @@ RSpec.describe Cloudtasker::Batch::Job do
     context 'with batch complete' do
       let(:complete) { true }
 
+      # The backstop claims the shared token before firing, so a concurrent child
+      # cannot also fire on_complete.
+      before do
+        expect(redis).to receive(:set)
+          .with(batch.batch_completion_gid, true, nx: true, ex: described_class::BATCH_COMPLETION_TTL)
+          .and_call_original
+      end
+
       after { expect(batch).to have_received(:on_complete) }
+      after { expect(parent_batch).to have_received(:on_batch_node_complete) }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'with batch complete but completion already claimed by another path' do
+      let(:complete) { true }
+
+      before do
+        expect(redis).to receive(:set)
+          .with(batch.batch_completion_gid, true, nx: true, ex: described_class::BATCH_COMPLETION_TTL)
+          .and_return(false)
+      end
+
+      # Token already held: on_complete must not fire, but node completion still
+      # propagates to the parent.
+      after { expect(batch).not_to have_received(:on_complete) }
       after { expect(parent_batch).to have_received(:on_batch_node_complete) }
       it { is_expected.to be_truthy }
     end


### PR DESCRIPTION
## The bug

`on_batch_complete` can be triggered from two code paths that may observe a batch as complete at the same time:

- **`on_child_complete`** — the last child to finish notifies the parent.
- **`complete`** — the parent's own post-`setup` backstop, run at the end of `execute`.

Only `on_child_complete` claimed the `batch_completion_gid` SETNX token before firing `on_complete`; `complete` fired it directly. When both observe `complete? == true` concurrently, `on_batch_complete` could fire twice.

## The fix

Extract the guarded fire into `trigger_completion(status)` and route both paths through it, so a concurrent backstop and child no longer both fire.

`on_batch_node_complete` stays outside the guard: it's a distinct per-node event that `complete` fires once on its own.

## Scope and limitations

The SETNX guard dedupes the common case: two paths racing to complete a batch that's still in flight. It does not handle Cloud Tasks delivering the same job twice — an uncommon at-least-once redelivery. A job that already completed can arrive after `cleanup` has wiped the batch state and the token, re-create a phantom slot, and re-fire `on_batch_complete`. Cloudtasker runs a job every time Cloud Tasks delivers it and never checks whether that job already ran, so workers needing exactly-once completion should keep `perform` and `on_batch_complete` idempotent.

## Related

Overlaps with #175 in `on_child_complete`. They fix independent bugs and compose cleanly, but they touch the same lines, so whichever lands first, the other needs a small rebase.